### PR TITLE
included CGPPINDEL process, it currently runs in 10minutes on the 100…

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -20,6 +20,7 @@ params {
 
     // CGPPINDEL
     docker.enabled = true
+    cgppindel_id = "cb44a611a143"
     help = false
     tumour = ""
     tumour_index = ""


### PR DESCRIPTION
Include the CGPPINDEL process. This process currently only returns the vcf itself, additional inputs originate from the DNAnexus cgppindel applet. It runs in around 10 minutes on 100k reads fastq files.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/uranus_nf_core_mini/3)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - A new configuration option has been added to enable additional customisation of analysis settings.
  - An enhanced analysis process now supports containerised execution with an in-built retry mechanism for robust performance, handling diverse genomic data inputs and delivering corresponding outputs reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->